### PR TITLE
Ensure user inserts return IDs for dependent records

### DIFF
--- a/app/Controllers/base/Order.php
+++ b/app/Controllers/base/Order.php
@@ -550,21 +550,20 @@ class Order extends Controller
 	 		'id_unik' => '',
 	 	];
 		
-		//insert dulu data user nya nanti diambil idnya 
-	 	$saveUser = $this->order->save_user($dataUser);
-	 	if(!$saveUser){
-	 		echo "<script>
-					alert('Terjadi Kesalahan! Silahkan coba beberapa saat lagi!');
-					document.location.href='order/any';
-					</script>";
-					exit();
-	 	}
-		
-	 	//global
-	 	$id_user = $this->db->insertID(); //ambil id user
-		$today = date('ym');
-	 	$kode = $today.$id_user.rand(10,99); //dijadikan invoice sekaligus kode unik user. Formatnya ( 2 digit tahun, 2 digit bulan, id user, random 2 angka)
-	 	$this->order->update_kode($kode,$id_user);
+                //insert dulu data user nya dan ambil idnya dari model agar konsisten
+                $id_user = $this->order->save_user($dataUser);
+                if(!$id_user){
+                        echo "<script>
+                                        alert('Terjadi Kesalahan! Silahkan coba beberapa saat lagi!');
+                                        document.location.href='order/any';
+                                        </script>";
+                                        exit();
+                }
+
+                //global
+                $today = date('ym');
+                $kode = $today.$id_user.rand(10,99); //dijadikan invoice sekaligus kode unik user. Formatnya ( 2 digit tahun, 2 digit bulan, id user, random 2 angka)
+                $this->order->update_kode($kode,$id_user);
 
 	 	//mempelai	
 	 	$nama_lengkap_pria = $this->session->get('nama_lengkap_pria');

--- a/app/Models/base/OrderModel.php
+++ b/app/Models/base/OrderModel.php
@@ -5,26 +5,26 @@ use CodeIgniter\Model;
 class OrderModel extends Model
 {
 
-	protected $acara,$cerita,$data,$komen,$maps,$mempelai,$order,$rules,$themes,$users,$album;
+    protected $db,$acara,$cerita,$data,$komen,$maps,$mempelai,$order,$rules,$themes,$users,$album;
 
-	public function __construct() {
+    public function __construct() {
 
         parent::__construct();
-        $db      = \Config\Database::connect();
-        $this->acara = $db->table('acara');
-        $this->cerita = $db->table('cerita');
-        $this->data = $db->table('data');
-        $this->komen = $db->table('komen');
-        $this->maps = $db->table('maps');
-        $this->mempelai = $db->table('mempelai');
-        $this->order = $db->table('order');
-        $this->rules = $db->table('rules');
-        $this->themes = $db->table('themes');
-        $this->users = $db->table('users');
-        $this->album = $db->table('album');
-        $this->pembayaran = $db->table('pembayaran');
-        $this->testimoni = $db->table('testimoni');
-        $this->setting = $db->table('setting');
+        $this->db      = \Config\Database::connect();
+        $this->acara = $this->db->table('acara');
+        $this->cerita = $this->db->table('cerita');
+        $this->data = $this->db->table('data');
+        $this->komen = $this->db->table('komen');
+        $this->maps = $this->db->table('maps');
+        $this->mempelai = $this->db->table('mempelai');
+        $this->order = $this->db->table('order');
+        $this->rules = $this->db->table('rules');
+        $this->themes = $this->db->table('themes');
+        $this->users = $this->db->table('users');
+        $this->album = $this->db->table('album');
+        $this->pembayaran = $this->db->table('pembayaran');
+        $this->testimoni = $this->db->table('testimoni');
+        $this->setting = $this->db->table('setting');
     }
 
     //untuk mengecek domain
@@ -75,7 +75,12 @@ class OrderModel extends Model
 
     public function save_user($data){
 
-    	return $this->users->insert($data);
+        $inserted = $this->users->insert($data);
+        if (! $inserted) {
+            return false;
+        }
+
+        return $this->db->insertID();
 
     }
 


### PR DESCRIPTION
## Summary
- update `OrderModel` to keep a reference to the shared database connection and return the inserted user ID when creating a record
- adjust the order workflow to rely on the returned user ID instead of querying the controller connection for it

## Testing
- php -l app/Controllers/base/Order.php
- php -l app/Models/base/OrderModel.php

------
https://chatgpt.com/codex/tasks/task_e_68e35e94af58832481e4c9d51390d9fd