### PR TITLE
Fix capture upload decoding and support slug-based guest lookups

### DIFF
--- a/app/Controllers/bukutamu/Bukutamu.php
+++ b/app/Controllers/bukutamu/Bukutamu.php
@@ -94,10 +94,23 @@ class Bukutamu extends Controller
         foreach ($datanya->getResult() as $row){ 
 	$kunci = $row->kunci;
 	}
-	$image = $_POST['image'];
-    $image = str_replace('data:image/png;base64,','', $image);
-	$image = base64_decode($image);
-	$filename = $qrcode.'.png';
+        $image = $this->request->getPost('image');
+
+        // Normalise base64 image payload from webcam.js which may return
+        // either JPEG or PNG formats depending on browser support.
+        $search = [
+            'data:image/png;base64,',
+            'data:image/jpeg;base64,',
+            'data:image/jpg;base64,',
+        ];
+        $image = str_replace($search, '', (string) $image);
+        $image = str_replace(' ', '+', $image);
+        $image = base64_decode($image);
+        if ($image === false) {
+            echo 'gagal';
+            return;
+        }
+        $filename = $qrcode.'.png';
 	$path = 'assets/users/'.$kunci;
         
         $cek = $this->BukutamuModel->cek_hadir($qrcode);


### PR DESCRIPTION
## Summary
- normalise webcam capture uploads to accept JPEG/PNG payloads and fail fast when decoding fails
- allow invitation pages to resolve guests by numeric id, name slug, address slug or QR code hash on both public and landing controllers by using a shared helper

## Testing
- php -l app/Controllers/bukutamu/Bukutamu.php
- php -l app/Models/undangan/UndanganModel.php
- php -l app/Models/base/BerandaModel.php

------
https://chatgpt.com/codex/tasks/task_e_68e3718bda44832482a0e04b535aec9c