### PR TITLE
Ensure profiles table has role column

### DIFF
--- a/app/Database/Migrations/2025-10-06-000001_AddRoleColumnToProfiles.php
+++ b/app/Database/Migrations/2025-10-06-000001_AddRoleColumnToProfiles.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddRoleColumnToProfiles extends Migration
+{
+    public function up()
+    {
+        if (! $this->db->tableExists('profiles')) {
+            return;
+        }
+
+        if ($this->db->fieldExists('role', 'profiles')) {
+            return;
+        }
+
+        $this->forge->addColumn('profiles', [
+            'role' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+                'default'    => 'user',
+                'null'       => false,
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        if (! $this->db->tableExists('profiles')) {
+            return;
+        }
+
+        if (! $this->db->fieldExists('role', 'profiles')) {
+            return;
+        }
+
+        $this->forge->dropColumn('profiles', 'role');
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration that adds the missing `role` column to the `profiles` table when it is absent

## Testing
- php -l app/Database/Migrations/2025-10-06-000001_AddRoleColumnToProfiles.php

------
https://chatgpt.com/codex/tasks/task_e_68e374504b908324a690d894a64328d7